### PR TITLE
Fix a bug with ClassInfo initialization after deserialization.

### DIFF
--- a/src/com/sun/tools/jmake/TextProjectDatabaseReader.java
+++ b/src/com/sun/tools/jmake/TextProjectDatabaseReader.java
@@ -86,7 +86,9 @@ public class TextProjectDatabaseReader {
         try {
             byte[] bytes = Base64.decode(s.toCharArray());
             ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes));
-            return (ClassInfo)ois.readObject();
+            ClassInfo ret = (ClassInfo)ois.readObject();
+            ret.initializeImmediateTransientFields();
+            return ret;
         } catch (IOException e) {
             throw new PrivateException(e);
         } catch (ClassNotFoundException e) {


### PR DESCRIPTION
In the text format.

Can I get a quick release of jmake? This turns out to be a showstopper for some other thing I'm doing. In fact I'm kinda surprised this ever worked.
