### PR TITLE
Change Hashtable and HashSet to LinkedHashMap and LinkedHashSet.

### DIFF
--- a/src/com/sun/tools/jmake/BinaryProjectDatabaseReader.java
+++ b/src/com/sun/tools/jmake/BinaryProjectDatabaseReader.java
@@ -7,35 +7,35 @@
 package com.sun.tools.jmake;
 
 import java.io.File;
-import java.util.Hashtable;
-
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * This class creates the internal representation of the project database from a byte array.
- * 
+ *
  * @author  Misha Dmitriev
  * @date 2 March 2005
  */
 public class BinaryProjectDatabaseReader extends BinaryFileReader {
 
     private String stringTable[];
-    private Hashtable<String,PCDEntry> pcd;
+    private Map<String,PCDEntry> pcd;
     private int nOfEntries;
     private int pdbFormat;  // Currently supported values: 0x01030300 (jmake 1.3.3 and newer versions); 1 (all older versions)
     // These are defined in Utils as PDB_FORMAT_CODE_LATEST and PDB_FORMAT_CODE_OLD
 
-    public Hashtable<String,PCDEntry> readProjectDatabaseFromFile(File infile) {
+    public Map<String,PCDEntry> readProjectDatabaseFromFile(File infile) {
         byte buf[] = Utils.readFileIntoBuffer(infile);
         return readProjectDatabase(buf, infile.toString());
     }
 
-    public Hashtable<String,PCDEntry> readProjectDatabase(byte[] pdbFile,
+    public Map<String,PCDEntry> readProjectDatabase(byte[] pdbFile,
             String pdbFileFullPath) {
         initBuf(pdbFile, pdbFileFullPath);
 
         readPreamble();
         readStringTable();
-        pcd = new Hashtable<String,PCDEntry>(nOfEntries * 4 / 3);
+        pcd = new LinkedHashMap<String,PCDEntry>(nOfEntries * 4 / 3);
 
         for (int i = 0; i < nOfEntries; i++) {
             PCDEntry entry = readPCDEntry();

--- a/src/com/sun/tools/jmake/BinaryProjectDatabaseWriter.java
+++ b/src/com/sun/tools/jmake/BinaryProjectDatabaseWriter.java
@@ -9,8 +9,7 @@ package com.sun.tools.jmake;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.util.Hashtable;
-import java.util.Enumeration;
+import java.util.Map;
 
 /**
  * This class implements writing into a byte array representing a project database
@@ -20,13 +19,13 @@ import java.util.Enumeration;
  */
 public class BinaryProjectDatabaseWriter extends BinaryFileWriter {
 
-    private Hashtable pcd = null;
+    private Map<String, PCDEntry> pcd = null;
     private int nOfEntries;
     private byte[] stringBuf;
     private int curStringBufPos,  stringBufInc,  curStringBufWatermark,  stringCount;
     private StringHashTable stringHashTable = null;
 
-    public void writeProjectDatabaseToFile(File outfile, Hashtable pcd) {
+    public void writeProjectDatabaseToFile(File outfile, Map<String, PCDEntry> pcd) {
         try {
             byte[] buf = new BinaryProjectDatabaseWriter().writeProjectDatabase(pcd);
             FileOutputStream out = new FileOutputStream(outfile);
@@ -37,7 +36,7 @@ public class BinaryProjectDatabaseWriter extends BinaryFileWriter {
         }
     }
 
-    public byte[] writeProjectDatabase(Hashtable pcd) {
+    public byte[] writeProjectDatabase(Map<String, PCDEntry> pcd) {
         this.pcd = pcd;
         nOfEntries = pcd.size();
 
@@ -49,9 +48,7 @@ public class BinaryProjectDatabaseWriter extends BinaryFileWriter {
         curStringBufWatermark = stringBuf.length - 20;
         stringHashTable = new StringHashTable(stringBuf.length / 8);
 
-        Enumeration entries = pcd.elements();
-        while (entries.hasMoreElements()) {
-            PCDEntry entry = (PCDEntry) entries.nextElement();
+        for (PCDEntry entry : pcd.values()) {
             writePCDEntry(entry);
         }
 

--- a/src/com/sun/tools/jmake/ClassInfo.java
+++ b/src/com/sun/tools/jmake/ClassInfo.java
@@ -8,11 +8,11 @@ package com.sun.tools.jmake;
 
 import java.io.Serializable;
 import java.lang.reflect.Modifier;
-import java.util.Set;
-import java.util.HashSet;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * A reflection of a class, in the form that allows fast checks and information obtaining.
@@ -20,6 +20,7 @@ import java.util.List;
  * @author Misha Dmitriev
  * @date 5 April 2004
  */
+@SuppressWarnings("serial")
 public class ClassInfo implements Serializable {
 
     public static final int VER_OLD = 0;  // Old version
@@ -154,13 +155,13 @@ public class ClassInfo implements Serializable {
      * class, that belong to the same project.
      */
     public Set<String> getAllImplementedIntfNames() {
-        Set<String> res = new HashSet<String>();
+        Set<String> res = new LinkedHashSet<String>();
         addImplementedInterfaceNames(false, res);
         return res;
     }
 
     /** Add to the given set the names of direct/all interfaces implemented by the given class. */
-    private void addImplementedInterfaceNames(boolean directOnly, 
+    private void addImplementedInterfaceNames(boolean directOnly,
             Set<String> intfSet) {
         if (interfaces != null) {
             for (int i = 0; i < interfaces.length; i++) {
@@ -179,7 +180,7 @@ public class ClassInfo implements Serializable {
             }
         }
 
-        if (directOnly || superName == null || 
+        if (directOnly || superName == null ||
                 "java/lang/Object".equals(superName)) {
             return;
         }
@@ -197,11 +198,9 @@ public class ClassInfo implements Serializable {
             return directSubclasses;
         }
 
-        Enumeration entries = pcdm.entriesEnum();
         List<ClassInfo> listRes = new ArrayList<ClassInfo>();
 
-        while (entries.hasMoreElements()) {
-            PCDEntry entry = (PCDEntry) entries.nextElement();
+        for (PCDEntry entry : pcdm.entries()) {
             ClassInfo classInfo = pcdm.getClassInfoForPCDEntry(verCode, entry);
             if (classInfo == null) {
                 continue;  // New or deleted class, depending on verCode

--- a/src/com/sun/tools/jmake/ClassPath.java
+++ b/src/com/sun/tools/jmake/ClassPath.java
@@ -7,22 +7,20 @@
 package com.sun.tools.jmake;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.FilenameFilter;
-
-import java.util.ArrayList;
-import java.util.StringTokenizer;
-import java.util.Collection;
-import java.util.Set;
-import java.util.Hashtable;
-
-import java.util.zip.ZipFile;
-import java.util.zip.ZipEntry;
-
+import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 /**
  * An instance of this class represents a class path, on which binary classes can be looked up.
@@ -50,7 +48,7 @@ public class ClassPath {
     // setClassPath() and setProjectClassPath() methods.
     private static String standardClassPathStr,  projectClassPathStr,  bootClassPathStr,  extDirsStr,
             virtualPathStr;
-    private static Hashtable<String,ClassInfo> classCache;
+    private static Map<String,ClassInfo> classCache;
 
 
     static {
@@ -68,7 +66,7 @@ public class ClassPath {
         compilerUserClassPath = null;
         standardClassPathStr = projectClassPathStr = bootClassPathStr =
                 extDirsStr = virtualPathStr = null;
-        classCache = new Hashtable<String,ClassInfo>();
+        classCache = new LinkedHashMap<String,ClassInfo>();
     }
 
     public static void setClassPath(String value) throws PublicExceptions.InvalidCmdOptionException {
@@ -202,7 +200,7 @@ public class ClassPath {
      * will recompile everything when they switch to a new JDK version. The optimization prevents us from wasting time
      * repeatedly loading the same sets of core classes.
      */
-    public static void getSuperclasses(String className, 
+    public static void getSuperclasses(String className,
             Collection<String> res, PCDManager pcdm) {
         int iterNo = 0;
         while (!"java/lang/Object".equals(className)) {
@@ -222,7 +220,7 @@ public class ClassPath {
      * projectClassPath or standardClassPath, plus the first interface on each branch that can be loaded from
      * coreClassPath. It's the same optimization as in getSuperclasses().
      */
-    public static void addAllImplementedInterfaceNames(String className, 
+    public static void addAllImplementedInterfaceNames(String className,
             Set<String> intfSet, PCDManager pcdm) {
         if ("java/lang/Object".equals(className)) {
             return;

--- a/src/com/sun/tools/jmake/CompatibilityChecker.java
+++ b/src/com/sun/tools/jmake/CompatibilityChecker.java
@@ -7,10 +7,8 @@
 package com.sun.tools.jmake;
 
 import java.lang.reflect.Modifier;
-
-import java.util.Set;
-import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 /**
  * This class implements checking of source compatibility of classes and supporting operations
@@ -170,11 +168,10 @@ public class CompatibilityChecker {
     }
 
     private void checkImplementedInterfaces() {
-        Set oldIntfNames = oldClassInfo.getAllImplementedIntfNames();
-        Set newIntfNames = newClassInfo.getAllImplementedIntfNames();
+        Set<String> oldIntfNames = oldClassInfo.getAllImplementedIntfNames();
+        Set<String> newIntfNames = newClassInfo.getAllImplementedIntfNames();
 
-        for (Iterator oldIntfIter = oldIntfNames.iterator(); oldIntfIter.hasNext();) {
-            String oldIntfName = (String) oldIntfIter.next();
+        for (String oldIntfName : oldIntfNames) {
             if (!newIntfNames.contains(oldIntfName)) {
                 versionsCompatible = false;
                 ClassInfo missingSuperInterface =
@@ -192,8 +189,7 @@ public class CompatibilityChecker {
 
         // Check if the class is abstract, and an interface has been added to its list of implemented interfaces
         if (newClassInfo.isAbstract()) {
-            for (Iterator newIntfIter = newIntfNames.iterator(); newIntfIter.hasNext();) {
-                String newIntfName = (String) newIntfIter.next();
+            for (String newIntfName : newIntfNames) {
                 if (!oldIntfNames.contains(newIntfName)) {
                     versionsCompatible = false;
                     rf.findConcreteSubclasses(oldClassInfo);
@@ -485,7 +481,7 @@ public class CompatibilityChecker {
                     // Check if the new method overloads an existing (declared or inherited) method. Overloading test is rough -
                     // we just check if the number of parameters is the same. Note that if a new constructor has been added, it
                     // can be treated in the same way, except that we shouldn't look up "same name methods" for it in superclasses.
-                    oldClassInfo.findExistingSameNameMethods(newMName, 
+                    oldClassInfo.findExistingSameNameMethods(newMName,
                             !newMName.equals("<init>"), false,
                             new ClassInfo.MethodHandler() {
 

--- a/src/com/sun/tools/jmake/Main.java
+++ b/src/com/sun/tools/jmake/Main.java
@@ -6,17 +6,15 @@
  */
 package com.sun.tools.jmake;
 
-import java.util.ArrayList;
-
-import java.io.PrintStream;
-import java.io.IOException;
-import java.io.Reader;
-import java.io.FileReader;
 import java.io.BufferedReader;
-import java.io.StreamTokenizer;
 import java.io.FileNotFoundException;
-
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.Reader;
+import java.io.StreamTokenizer;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -34,7 +32,7 @@ import java.util.List;
 public class Main {
 
     static final String DEFAULT_STORE_NAME = "jmake.pdb";
-    static final String VERSION = "1.3.8-3";
+    static final String VERSION = "1.3.8-4";
     private String pdbFileName = null;
     private List<String> allProjectJavaFileNamesList =
             new ArrayList<String>(100);
@@ -261,7 +259,7 @@ public class Main {
             st.commentChar('#');
             st.quoteChar('"');
             st.quoteChar('\'');
-            while (st.nextToken() != st.TT_EOF) {
+            while (st.nextToken() != StreamTokenizer.TT_EOF) {
                 argsV.add(st.sval);
             }
             r.close();

--- a/src/com/sun/tools/jmake/PCDContainer.java
+++ b/src/com/sun/tools/jmake/PCDContainer.java
@@ -6,11 +6,9 @@
  */
 package com.sun.tools.jmake;
 
-import java.io.IOException;
 import java.io.File;
-import java.io.FileOutputStream;
-
-import java.util.Hashtable;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * This class is a persistent container for the Project Class Directory, that can
@@ -21,13 +19,13 @@ import java.util.Hashtable;
  */
 public class PCDContainer {
 
-    /** The data structure (currently Hashtable) for PCD, that maps class name to
+    /** The data structure (currently {@link LinkedHashMap}) for PCD, that maps class name to
     record containing information about the class */
-    Hashtable<String,PCDEntry> pcd;
+    Map<String,PCDEntry> pcd;
     String storeName;
     boolean textFormat;
 
-    private PCDContainer(Hashtable<String,PCDEntry> pcd, String storeName, boolean textFormat) {
+    private PCDContainer(Map<String,PCDEntry> pcd, String storeName, boolean textFormat) {
         this.storeName = storeName;
         this.pcd = pcd;
         this.textFormat = textFormat;
@@ -40,7 +38,7 @@ public class PCDContainer {
         File storeFile = Utils.checkFileForName(storeName);
         if (storeFile != null) {
             Utils.printInfoMessageNoEOL("Opening project database...  ");
-            Hashtable<String,PCDEntry> pcd;
+            Map<String,PCDEntry> pcd;
             if (textFormat) {
                 pcd = new TextProjectDatabaseReader().readProjectDatabaseFromFile(storeFile);
             } else {

--- a/src/com/sun/tools/jmake/RefClassFinder.java
+++ b/src/com/sun/tools/jmake/RefClassFinder.java
@@ -6,12 +6,9 @@
  */
 package com.sun.tools.jmake;
 
-import java.util.Set;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Enumeration;
-
 import java.lang.reflect.Modifier;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
  * This class implements finding classes referencing other classes and members in various ways.
@@ -40,7 +37,7 @@ public class RefClassFinder {
     public void initialize(String checkedClassName, boolean checkedClassIsFromJar) {
         this.checkedClassName = checkedClassName;
         this.checkedClassIsFromJar = checkedClassIsFromJar;
-        affectedClassNames = new HashSet<String>();
+        affectedClassNames = new LinkedHashSet<String>();
     }
 
     /**
@@ -53,10 +50,9 @@ public class RefClassFinder {
             return null;
         } else {
             String[] ret = new String[size];
-            Iterator<String> iter = affectedClassNames.iterator();
             int i = 0;
-            while (iter.hasNext()) {
-                ret[i++] = iter.next();
+            for (String className : affectedClassNames) {
+                ret[i++] = className;
             }
             return ret;
         }
@@ -67,8 +63,7 @@ public class RefClassFinder {
      * Used if a compile-time constant is changed.
      */
     public void findAllProjectClasses(ClassInfo fieldClassInfo, int fieldNo) {
-        for (Enumeration pcdEntries = pcdm.entriesEnum(); pcdEntries.hasMoreElements();) {
-            PCDEntry pcde = (PCDEntry) pcdEntries.nextElement();
+        for (PCDEntry pcde : pcdm.entries()) {
             if (pcde.checkResult == PCDEntry.CV_DELETED) {
                 continue;
             }
@@ -105,10 +100,9 @@ public class RefClassFinder {
         String packageName = classInfo.packageName;
         boolean isPublic = classInfo.isPublic();
         boolean isInterface = classInfo.isInterface();
-        Enumeration<PCDEntry> pcdEntries = pcdm.entriesEnum();
-        while (pcdEntries.hasMoreElements()) {
+        for (PCDEntry pcde : pcdm.entries()) {
             ClassInfo clientInfo =
-                    pcdm.getClassInfoForPCDEntry(ClassInfo.VER_OLD, pcdEntries.nextElement());
+                    pcdm.getClassInfoForPCDEntry(ClassInfo.VER_OLD, pcde);
             if (clientInfo == null) {
                 continue;  // New class
             }
@@ -130,10 +124,9 @@ public class RefClassFinder {
     public void findDiffPackageAndNotSubReferencingClasses1(ClassInfo classInfo) {
         String packageName = classInfo.packageName;
         String directlyEnclosingClass = classInfo.directlyEnclosingClass;
-        Enumeration pcdEntries = pcdm.entriesEnum();
-        while (pcdEntries.hasMoreElements()) {
+        for (PCDEntry pcde : pcdm.entries()) {
             ClassInfo clientInfo =
-                    pcdm.getClassInfoForPCDEntry(ClassInfo.VER_OLD, (PCDEntry) pcdEntries.nextElement());
+                    pcdm.getClassInfoForPCDEntry(ClassInfo.VER_OLD, pcde);
             if (clientInfo == null) {
                 continue;  // New class
             }
@@ -154,11 +147,9 @@ public class RefClassFinder {
      */
     public void findReferencingClasses1(ClassInfo classInfo) {
         String topLevelEnclosingClass = classInfo.topLevelEnclosingClass;
-        Enumeration pcdEntries = pcdm.entriesEnum();
-        while (pcdEntries.hasMoreElements()) {
+        for (PCDEntry pcde : pcdm.entries()) {
             ClassInfo clientInfo =
-                    pcdm.getClassInfoForPCDEntry(ClassInfo.VER_OLD,
-                    (PCDEntry) pcdEntries.nextElement());
+                    pcdm.getClassInfoForPCDEntry(ClassInfo.VER_OLD, pcde);
             if (clientInfo == null) {
                 continue;  // New class
             }
@@ -181,11 +172,9 @@ public class RefClassFinder {
         String directlyEnclosingClass = classInfo.directlyEnclosingClass;
         String topLevelEnclosingClass = classInfo.topLevelEnclosingClass;
         String packageName = classInfo.packageName;
-        Enumeration pcdEntries = pcdm.entriesEnum();
-        while (pcdEntries.hasMoreElements()) {
+        for (PCDEntry entry : pcdm.entries()) {
             ClassInfo clientInfo =
-                    pcdm.getClassInfoForPCDEntry(ClassInfo.VER_OLD,
-                    (PCDEntry) pcdEntries.nextElement());
+                    pcdm.getClassInfoForPCDEntry(ClassInfo.VER_OLD, entry);
             if (clientInfo == null) {
                 continue;  // New class
             }
@@ -210,11 +199,10 @@ public class RefClassFinder {
     public void findThisPackageReferencingClasses1(ClassInfo classInfo) {
         String topLevelEnclosingClass = classInfo.topLevelEnclosingClass;
         String packageName = classInfo.packageName;
-        Enumeration pcdEntries = pcdm.entriesEnum();
-        while (pcdEntries.hasMoreElements()) {
+        for (PCDEntry entry : pcdm.entries()) {
             ClassInfo clientInfo =
                     pcdm.getClassInfoForPCDEntry(ClassInfo.VER_OLD,
-                    (PCDEntry) pcdEntries.nextElement());
+                        entry);
             if (clientInfo == null) {
                 continue;  // New class
             }
@@ -236,11 +224,9 @@ public class RefClassFinder {
      */
     public void findDiffPackageReferencingClasses1(ClassInfo classInfo) {
         String packageName = classInfo.packageName;
-        Enumeration pcdEntries = pcdm.entriesEnum();
-        while (pcdEntries.hasMoreElements()) {
+        for (PCDEntry pcde : pcdm.entries()) {
             ClassInfo clientInfo =
-                    pcdm.getClassInfoForPCDEntry(ClassInfo.VER_OLD,
-                    (PCDEntry) pcdEntries.nextElement());
+                    pcdm.getClassInfoForPCDEntry(ClassInfo.VER_OLD, pcde);
             if (clientInfo == null) {
                 continue;  // New class
             }
@@ -261,11 +247,9 @@ public class RefClassFinder {
     public void findDiffPackageAndSubReferencingClasses1(ClassInfo classInfo) {
         String packageName = classInfo.packageName;
         String directlyEnclosingClass = classInfo.directlyEnclosingClass;
-        Enumeration pcdEntries = pcdm.entriesEnum();
-        while (pcdEntries.hasMoreElements()) {
+        for (PCDEntry pcde : pcdm.entries()) {
             ClassInfo clientInfo =
-                    pcdm.getClassInfoForPCDEntry(ClassInfo.VER_OLD,
-                    (PCDEntry) pcdEntries.nextElement());
+                    pcdm.getClassInfoForPCDEntry(ClassInfo.VER_OLD, pcde);
             if (clientInfo == null) {
                 continue;  // New class
             }
@@ -289,14 +273,12 @@ public class RefClassFinder {
      * direct/indirect superclass.
      */
     public void findReferencingClasses2(ClassInfo classInfo1, ClassInfo classInfo2) {
-        HashSet<String> refClazz1 = new HashSet<String>();
+        Set<String> refClazz1 = new LinkedHashSet<String>();
         findReferencingClasses(classInfo1, 2, false, refClazz1);
-        HashSet<String> refClazz2 = new HashSet<String>();
+        Set<String> refClazz2 = new LinkedHashSet<String>();
         findReferencingClasses(classInfo2, 2, false, refClazz2);
 
-        Iterator<String> iter1 = refClazz1.iterator();
-        while (iter1.hasNext()) {
-            String className1 = iter1.next();
+        for (String className1 : refClazz1) {
             if (refClazz2.contains(className1)) {
                 addToAffectedClassNames(className1);
             }
@@ -305,9 +287,8 @@ public class RefClassFinder {
 
     /** Find all project classes which are direct subclasses of the given class */
     public void findDirectSubclasses(ClassInfo classInfo) {
-        ClassInfo[] subclasses = classInfo.getDirectSubclasses();
-        for (int i = 0; i < subclasses.length; i++) {
-            addToAffectedClassNames(subclasses[i].name);
+        for (ClassInfo subclassInfo : classInfo.getDirectSubclasses()) {
+            addToAffectedClassNames(subclassInfo.name);
         }
     }
 
@@ -318,10 +299,9 @@ public class RefClassFinder {
      * interface I indirectly, if C or some superclass of C directly implements I or some sublcass of I.
      */
     public void findDirectlyAndOtherwiseImplementingConcreteClasses(ClassInfo intfInfo) {
-        Enumeration pcdEntries = pcdm.entriesEnum();
-        while (pcdEntries.hasMoreElements()) {
+        for (PCDEntry entry : pcdm.entries()) {
             ClassInfo clientInfo =
-                    pcdm.getClassInfoForPCDEntry(ClassInfo.VER_OLD, (PCDEntry) pcdEntries.nextElement());
+                    pcdm.getClassInfoForPCDEntry(ClassInfo.VER_OLD, entry);
             if (clientInfo == null) {
                 continue;  // New class
             }
@@ -341,12 +321,11 @@ public class RefClassFinder {
     }
 
     private void findAllNearestConcreteSubclasses(ClassInfo classInfo) {
-        ClassInfo[] subclasses = classInfo.getDirectSubclasses();
-        for (int i = 0; i < subclasses.length; i++) {
-            if (subclasses[i].isAbstract()) {
-                findAllNearestConcreteSubclasses(subclasses[i]);
+        for (ClassInfo subclassInfo : classInfo.getDirectSubclasses()) {
+            if (subclassInfo.isAbstract()) {
+                findAllNearestConcreteSubclasses(subclassInfo);
             } else {
-                addToAffectedClassNames(subclasses[i].name);
+                addToAffectedClassNames(subclassInfo.name);
             }
         }
     }
@@ -356,10 +335,9 @@ public class RefClassFinder {
      * a method with the given name. For those that overload this method, find referencing classes.
      */
     public void findAbstractSubtypesWithSameNameMethod(ClassInfo intfInfo, String mName, final String mSig) {
-        Enumeration pcdEntries = pcdm.entriesEnum();
-        while (pcdEntries.hasMoreElements()) {
+        for (PCDEntry pcde : pcdm.entries()) {
             ClassInfo ci =
-                    pcdm.getClassInfoForPCDEntry(ClassInfo.VER_OLD, (PCDEntry) pcdEntries.nextElement());
+                    pcdm.getClassInfoForPCDEntry(ClassInfo.VER_OLD, pcde);
             if (ci == null) {
                 continue;  // New class or not in project
             }
@@ -439,9 +417,7 @@ public class RefClassFinder {
     }
 
     private void findSubclassesReimplementingMethod(ClassInfo targetClass, ClassInfo methodDeclaringClass, int methodNo) {
-        ClassInfo[] subclasses = targetClass.getDirectSubclasses();
-        for (int i = 0; i < subclasses.length; i++) {
-            ClassInfo subclass = subclasses[i];
+        for (ClassInfo subclass : targetClass.getDirectSubclasses()) {
             if (subclass.declaresMethod(methodDeclaringClass, methodNo)) {
                 addToAffectedClassNames(subclass.name);
             } else {
@@ -455,9 +431,7 @@ public class RefClassFinder {
      * or indirect abstract subclasses.
      */
     public void findConcreteSubclasses(ClassInfo targetClass) {
-        ClassInfo[] subclasses = targetClass.getDirectSubclasses();
-        for (int i = 0; i < subclasses.length; i++) {
-            ClassInfo subclass = subclasses[i];
+        for (ClassInfo subclass : targetClass.getDirectSubclasses()) {
             if (subclass.isAbstract()) {
                 findConcreteSubclasses(subclass);
             } else {
@@ -471,9 +445,7 @@ public class RefClassFinder {
      * of the given method.
      */
     public void findConcreteSubclassesNotOverridingAbstractMethod(ClassInfo targetClass, ClassInfo methodDeclaringClass, int methodNo) {
-        ClassInfo[] subclasses = targetClass.getDirectSubclasses();
-        for (int i = 0; i < subclasses.length; i++) {
-            ClassInfo subclass = subclasses[i];
+        for (ClassInfo subclass : targetClass.getDirectSubclasses()) {
             int pos =
                     subclass.getDeclaredMethodPos(methodDeclaringClass, methodNo);
             if (pos == -1) { // This method is not overridden in this class
@@ -492,10 +464,9 @@ public class RefClassFinder {
 
     /** Find all project classes that reference any method that throws the given exception. */
     public void findRefsToMethodsThrowingException(ClassInfo excClassInfo) {
-        Enumeration pcdEntries = pcdm.entriesEnum();
-        while (pcdEntries.hasMoreElements()) {
+            for (PCDEntry pcde : pcdm.entries()) {
             ClassInfo classInfo =
-                    pcdm.getClassInfoForPCDEntry(ClassInfo.VER_OLD, (PCDEntry) pcdEntries.nextElement());
+                    pcdm.getClassInfoForPCDEntry(ClassInfo.VER_OLD, pcde);
             if (classInfo == null) {
                 continue;  // New class
             }
@@ -515,15 +486,13 @@ public class RefClassFinder {
      * classes referencing given class X via the "X.class" construct.
      */
     public void findClassesDeclaringField(String name, String signature, boolean isStatic, String packageToLookIn) {
-        Enumeration pcdEntries = pcdm.entriesEnum();
-        while (pcdEntries.hasMoreElements()) {
+        for (PCDEntry pcde : pcdm.entries()) {
             ClassInfo classInfo =
-                    pcdm.getClassInfoForPCDEntry(ClassInfo.VER_OLD,
-                    (PCDEntry) pcdEntries.nextElement());
+                    pcdm.getClassInfoForPCDEntry(ClassInfo.VER_OLD, pcde);
             if (classInfo == null) {
                 continue;  // New class
             }
-            if (packageToLookIn != null && 
+            if (packageToLookIn != null &&
                     !classInfo.packageName.equals(packageToLookIn)) {
                 continue;
             }
@@ -559,12 +528,11 @@ public class RefClassFinder {
      */
     private void findReferencingClasses(ClassInfo classInfo,
             int thorDegree, boolean fromDiffPackages,
-            HashSet<String> ret) {
+            Set<String> ret) {
         String packageName = classInfo.packageName;
-        Enumeration pcdEntries = pcdm.entriesEnum();
-        while (pcdEntries.hasMoreElements()) {
+        for (PCDEntry pcde : pcdm.entries()) {
             ClassInfo clientInfo =
-                    pcdm.getClassInfoForPCDEntry(ClassInfo.VER_OLD, (PCDEntry) pcdEntries.nextElement());
+                    pcdm.getClassInfoForPCDEntry(ClassInfo.VER_OLD, pcde);
             if (clientInfo == null) {
                 continue;  // New class
             }
@@ -599,11 +567,9 @@ public class RefClassFinder {
             boolean fromDiffPackages, boolean onlySubclasses) {
         String declaringClassName = declaringClassInfo.name;
         String declaringClassPackage = declaringClassInfo.packageName;
-        Enumeration pcdEntries = pcdm.entriesEnum();
-        while (pcdEntries.hasMoreElements()) {
+        for (PCDEntry pcde : pcdm.entries()) {
             ClassInfo clientInfo =
-                    pcdm.getClassInfoForPCDEntry(ClassInfo.VER_OLD,
-                    (PCDEntry) pcdEntries.nextElement());
+                    pcdm.getClassInfoForPCDEntry(ClassInfo.VER_OLD, pcde);
             if (clientInfo == null) {
                 continue;  // New class
             }
@@ -614,7 +580,7 @@ public class RefClassFinder {
             if (!memberAccessibleFrom(declaringClassInfo, memberNo, clientInfo, isField)) {
                 continue;
             }
-            if (fromDiffPackages && 
+            if (fromDiffPackages &&
                     declaringClassPackage.equals(clientInfo.packageName)) {
                 continue;
             }

--- a/src/com/sun/tools/jmake/TextProjectDatabaseReader.java
+++ b/src/com/sun/tools/jmake/TextProjectDatabaseReader.java
@@ -6,8 +6,17 @@
  */
 package com.sun.tools.jmake;
 
-import java.io.*;
-import java.util.Hashtable;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.ObjectInputStream;
+import java.io.UnsupportedEncodingException;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -23,7 +32,7 @@ import java.util.regex.Pattern;
  * @date 13 January 2013
  */
 public class TextProjectDatabaseReader {
-    public Hashtable<String,PCDEntry> readProjectDatabaseFromFile(File infile) {
+    public Map<String,PCDEntry> readProjectDatabaseFromFile(File infile) {
         try {
             BufferedReader in =
                 new BufferedReader(new InputStreamReader(new FileInputStream(infile), "UTF-8"));
@@ -41,8 +50,8 @@ public class TextProjectDatabaseReader {
         }
     }
 
-    public Hashtable<String,PCDEntry> readProjectDatabase(BufferedReader in) {
-        Hashtable<String,PCDEntry> pcd;
+    public Map<String,PCDEntry> readProjectDatabase(BufferedReader in) {
+        Map<String,PCDEntry> pcd;
         try {
             String line = in.readLine();
             if (!"pcd entries:".equals(line))
@@ -52,7 +61,7 @@ public class TextProjectDatabaseReader {
             if (!m.matches())
                 throw error("Expected: '<n> items', got: " + line);
             int numEntries = Integer.parseInt(m.group(1));
-            pcd = new Hashtable<String, PCDEntry>(numEntries);
+            pcd = new LinkedHashMap<String, PCDEntry>(numEntries);
             for (int i = 0; i < numEntries; i++) {
                 line = in.readLine();
                 if (line == null)

--- a/src/com/sun/tools/jmake/TextProjectDatabaseWriter.java
+++ b/src/com/sun/tools/jmake/TextProjectDatabaseWriter.java
@@ -6,8 +6,21 @@
  */
 package com.sun.tools.jmake;
 
-import java.io.*;
-import java.util.*;
+import java.io.BufferedWriter;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.UnsupportedEncodingException;
+import java.io.Writer;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
 
 
 /**
@@ -19,13 +32,13 @@ import java.util.*;
  * @date 13 January 2013
  */
 public class TextProjectDatabaseWriter {
-    private static Set<String> primitives = new HashSet<String>(
+    private static Set<String> primitives = new LinkedHashSet<String>(
         Arrays.asList("boolean", "byte", "char", "double", "float", "int", "long", "short",
                       "Z", "B", "C", "D", "F", "I", "J", "S"));
 
     private ByteArrayOutputStream baos = new ByteArrayOutputStream();  // Reusable temp buffer.
 
-    public void writeProjectDatabaseToFile(File outfile, Hashtable<String, PCDEntry> pcd) {
+    public void writeProjectDatabaseToFile(File outfile, Map<String, PCDEntry> pcd) {
         try {
             Writer out = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(outfile), "UTF-8"));
             try {
@@ -42,19 +55,17 @@ public class TextProjectDatabaseWriter {
         }
     }
 
-	public void writeProjectDatabase(Writer out, Hashtable<String,PCDEntry> pcd) {
+	public void writeProjectDatabase(Writer out, Map<String,PCDEntry> pcd) {
         try {
             out.write("pcd entries:\n");
             out.write(Integer.toString(pcd.size()));
             out.write(" items\n");
-            Map<String, Set<String>> depsBySource = new HashMap<String, Set<String>>();
-            Enumeration<PCDEntry> entries = pcd.elements();
-            while (entries.hasMoreElements()) {
-                PCDEntry entry = entries.nextElement();
+            Map<String, Set<String>> depsBySource = new LinkedHashMap<String, Set<String>>();
+            for (PCDEntry entry : pcd.values()) {
                 writePCDEntry(out, entry);
                 Set<String> deps = depsBySource.get(entry.javaFileFullPath);
                 if (deps == null) {
-                    deps = new HashSet<String>();
+                    deps = new LinkedHashSet<String>();
                     depsBySource.put(entry.javaFileFullPath, deps);
                 }
                 addDepsFromClassInfo(deps, entry.oldClassInfo);

--- a/src/com/sun/tools/jmake/ant/JavaMake.java
+++ b/src/com/sun/tools/jmake/ant/JavaMake.java
@@ -191,11 +191,13 @@ public class JavaMake extends Javac {
         File destDir = getDestdir();
 
         // Create a method object for method "compileSourceFiles" to call back
-        Class thisClass = this.getClass();
+        Class<?> thisClass = this.getClass();
         Method compileSourceFilesMethod;
         try {
-            compileSourceFilesMethod = thisClass.getDeclaredMethod(
-                    "compileSourceFiles", new Class[]{String[].class});
+          Class<?>[] args = new Class<?>[]{String[].class};
+
+          compileSourceFilesMethod = thisClass.getDeclaredMethod(
+                    "compileSourceFiles", args);
         } catch (Exception e) {
             throw new BuildException(e.getMessage() + "\n Should not happen!");
         }
@@ -212,11 +214,11 @@ public class JavaMake extends Javac {
         try {
             Path compilePath = getClasspath();
             if (compilePath != null) {
-                jmake.setClassPath(compilePath.toString());
+                Main.setClassPath(compilePath.toString());
             }
             Path path = getProjClasspath();
             if (path != null) {
-                jmake.setProjectClassPath(path.toString());
+                Main.setProjectClassPath(path.toString());
             }
             if (compilePath == null) {
                 compilePath = path;
@@ -226,11 +228,11 @@ public class JavaMake extends Javac {
             setClasspath(compilePath);
             path = getBootclasspath();
             if (path != null) {
-                jmake.setBootClassPath(path.toString());
+                Main.setBootClassPath(path.toString());
             }
             path = getExtdirs();
             if (path != null) {
-                jmake.setExtDirs(path.toString());
+                Main.setExtDirs(path.toString());
             }
         } catch (Exception e) {
             /* Should not happen - Ant has already checked paths */
@@ -244,7 +246,7 @@ public class JavaMake extends Javac {
         // Initialize (or re-initialize) jmake's internal "out" and "err" stream variables - important
         // in situations when e.g. an IDE that launches the Ant script may redefine System.out and System.err
         // in between Ant invocations
-        jmake.setOutputStreams(System.out, System.out, System.err);
+        Main.setOutputStreams(System.out, System.out, System.err);
 
         int res =
                 jmake.mainExternalControlled(

--- a/test/com/sun/tools/jmake/PCDSerializationTest.java
+++ b/test/com/sun/tools/jmake/PCDSerializationTest.java
@@ -1,14 +1,15 @@
 package com.sun.tools.jmake;
 
-import org.junit.Test;
-
 import java.io.StringWriter;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.Hashtable;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
+import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 
 public class PCDSerializationTest {
@@ -39,7 +40,7 @@ public class PCDSerializationTest {
             { "[C", "[java/lang/Class" }
         };
         String[] expectedMungedDeps = { "java/lang/Object", "java/lang/Class" };
-        Hashtable<String,PCDEntry> pcds = new Hashtable<String,PCDEntry>();
+        Map<String,PCDEntry> pcds = new LinkedHashMap<String,PCDEntry>();
         addDeps(pcds, "foo/bar/Baz", testDeps[0]);
         addDeps(pcds, "foo/bar/Baz$", testDeps[1]);
 
@@ -52,17 +53,17 @@ public class PCDSerializationTest {
         String src = deps[0];
         assertEquals("/root/foo/bar/Baz.java", src);
 
-        Set<String> expectedMungedDepsSet = new HashSet<String>();
+        Set<String> expectedMungedDepsSet = new LinkedHashSet<String>();
         Collections.addAll(expectedMungedDepsSet, expectedMungedDeps);
 
-        Set<String> actualMungedDepsSet = new HashSet<String>();
+        Set<String> actualMungedDepsSet = new LinkedHashSet<String>();
         for (int i = 1; i < deps.length; i++) {
             actualMungedDepsSet.add(deps[i]);
         }
         assertEquals(expectedMungedDepsSet, actualMungedDepsSet);
     }
 
-    private void addDeps(Hashtable<String,PCDEntry> pcds, String cls, String[] deps) {
+    private void addDeps(Map<String,PCDEntry> pcds, String cls, String[] deps) {
         ClassInfo ci = new ClassInfo();
         ci.cpoolRefsToClasses = deps;
         pcds.put(cls, new PCDEntry(cls, "/root/foo/bar/Baz.java", 0, 0, ci));


### PR DESCRIPTION
This is intended to be a straightforward refactoring of jmake to make it run more deterministically.  At some point we instituted a policy in GWT of using the Linked\* variants everywhere to keep problems related to iterating through sets and maps in different orders from cropping up.
- Convert Hashtable to LinkedHashMap
- Convert HashSet to LinkedHashSet

Since I had to change walking Hashtable entries with Enumeration to something else, I kept going with changes to get rid of warnings related to types.  
- Changed Enumeration and Iterators in most places to use for ... in  loops
- Added types/wildcards to get rid of raw type warnings

After doing this, 'ant jar' runs without any warnings from the code.  We have not noticed any noticeable impact in Pants positive or negative, but in my IDE the warnings that are left are pointing out more useful stuff.  I didn't want to go any further with changes than these which should have zero impact on the logic.

Also, these refactorings take us further from the 'published' version of jmake, I'm not sure how much we care about that.
