### PR TITLE
Some fixes to compile with jdk 1.8 on a macbook

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -4,7 +4,7 @@
 
 
 function die() {
-    echo "$1"
+    echo "FATAL: $1"
     exit 1
 }
 
@@ -17,7 +17,8 @@ ant package_for_release || die "failed to package"
 version=$(java -jar dist/release/jmake.jar -version 2>/dev/null | cut -d ' ' -f 3)
 
 # Use jarjar to rewrite jar:
-java -jar $JARJAR_JAR process rename.rules dist/release/jmake.jar dist/release/jmake-renamed.jar || die "jarjar failed"
+test -e ${JARJAR_JAR} || die "must have a copy of jarjar.jar installed default \$JARJAR_JAR=${JARJAR_JAR}"
+java -jar ${JARJAR_JAR} process rename.rules dist/release/jmake.jar dist/release/jmake-renamed.jar || die "jarjar failed"
 
 test -n "$version" || die "Could not get version"
 

--- a/rename.rules
+++ b/rename.rules
@@ -3,4 +3,3 @@ zap testcase1.**
 zap testcase2.**
 zap packageinfo.**
 zap classfilereader.**
-

--- a/src/com/sun/tools/jmake/BinaryFileReader.java
+++ b/src/com/sun/tools/jmake/BinaryFileReader.java
@@ -14,7 +14,7 @@ import java.io.IOException;
  * Basic operations for reading a byte array representing a binary file.
  *
  * @author  Misha Dmitriev
- * @date 10 November 2001
+ *  10 November 2001
  */
 public class BinaryFileReader {
 

--- a/src/com/sun/tools/jmake/BinaryFileWriter.java
+++ b/src/com/sun/tools/jmake/BinaryFileWriter.java
@@ -10,7 +10,7 @@ package com.sun.tools.jmake;
  * Basic operations for writing to a byte array representing a binary file.
  *
  * @author  Misha Dmitriev
- * @date 30 January 2002
+ *  30 January 2002
  */
 public class BinaryFileWriter {
 

--- a/src/com/sun/tools/jmake/BinaryProjectDatabaseReader.java
+++ b/src/com/sun/tools/jmake/BinaryProjectDatabaseReader.java
@@ -14,7 +14,7 @@ import java.util.Map;
  * This class creates the internal representation of the project database from a byte array.
  *
  * @author  Misha Dmitriev
- * @date 2 March 2005
+ *  2 March 2005
  */
 public class BinaryProjectDatabaseReader extends BinaryFileReader {
 

--- a/src/com/sun/tools/jmake/BinaryProjectDatabaseWriter.java
+++ b/src/com/sun/tools/jmake/BinaryProjectDatabaseWriter.java
@@ -15,7 +15,7 @@ import java.util.Map;
  * This class implements writing into a byte array representing a project database
  *
  * @author  Misha Dmitriev
- * @date 2 March 2005
+ *  2 March 2005
  */
 public class BinaryProjectDatabaseWriter extends BinaryFileWriter {
 

--- a/src/com/sun/tools/jmake/ClassFileReader.java
+++ b/src/com/sun/tools/jmake/ClassFileReader.java
@@ -13,7 +13,7 @@ import java.lang.reflect.Modifier;
  * This class implements reading a byte array representing a class file and converting it into ClassInfo.
  *
  * @author  Misha Dmitriev
- * @date 2 March 2005
+ *  2 March 2005
  */
 public class ClassFileReader extends BinaryFileReader {
 

--- a/src/com/sun/tools/jmake/ClassInfo.java
+++ b/src/com/sun/tools/jmake/ClassInfo.java
@@ -18,7 +18,7 @@ import java.util.Set;
  * A reflection of a class, in the form that allows fast checks and information obtaining.
  *
  * @author Misha Dmitriev
- * @date 5 April 2004
+ *  5 April 2004
  */
 @SuppressWarnings("serial")
 public class ClassInfo implements Serializable {

--- a/src/com/sun/tools/jmake/ClassPath.java
+++ b/src/com/sun/tools/jmake/ClassPath.java
@@ -28,7 +28,7 @@ import java.util.zip.ZipFile;
  * throughout jmake.
  *
  * @author Misha Dmitriev
- * @date 12 October 2004
+ *  12 October 2004
  */
 public class ClassPath {
 

--- a/src/com/sun/tools/jmake/CompatibilityChecker.java
+++ b/src/com/sun/tools/jmake/CompatibilityChecker.java
@@ -14,7 +14,7 @@ import java.util.Set;
  * This class implements checking of source compatibility of classes and supporting operations
  *
  * @author Misha Dmitriev
- * @date 12 March 2004
+ *  12 March 2004
  */
 public class CompatibilityChecker {
 

--- a/src/com/sun/tools/jmake/Main.java
+++ b/src/com/sun/tools/jmake/Main.java
@@ -27,7 +27,7 @@ import java.util.List;
  * See method comments for more details.
  *
  * @author Misha Dmitriev
- * @date 12 October 2004
+ *  12 October 2004
  */
 public class Main {
 

--- a/src/com/sun/tools/jmake/PCDContainer.java
+++ b/src/com/sun/tools/jmake/PCDContainer.java
@@ -15,7 +15,7 @@ import java.util.Map;
  * read and write itself from/to disk.
  *
  * @author Misha Dmitriev
- * @date 12 November 2001
+ *  12 November 2001
  */
 public class PCDContainer {
 

--- a/src/com/sun/tools/jmake/PCDEntry.java
+++ b/src/com/sun/tools/jmake/PCDEntry.java
@@ -12,7 +12,7 @@ import java.io.File;
  * An instance of this class represents an entry in the Project Class Directory.
  *
  * @author Misha Dmitriev
- * @date 29 March 2002
+ *  29 March 2002
  */
 public class PCDEntry {
     // Class versions compare results

--- a/src/com/sun/tools/jmake/PCDManager.java
+++ b/src/com/sun/tools/jmake/PCDManager.java
@@ -38,7 +38,7 @@ import java.util.zip.Adler32;
  * of changes and recompilation of .java sources for a project.
  *
  * @author Misha Dmitriev
- * @date 23 January 2003
+ *  23 January 2003
  */
 public class PCDManager {
 

--- a/src/com/sun/tools/jmake/PrivateException.java
+++ b/src/com/sun/tools/jmake/PrivateException.java
@@ -11,7 +11,7 @@ package com.sun.tools.jmake;
  * only purpose is to help avoid using endless "throws" clauses in the code.
  *
  * @author  Misha Dmitriev
- * @date 12 November 2001
+ *  12 November 2001
  */
 public class PrivateException extends RuntimeException {
 

--- a/src/com/sun/tools/jmake/PublicExceptions.java
+++ b/src/com/sun/tools/jmake/PublicExceptions.java
@@ -16,7 +16,7 @@ package com.sun.tools.jmake;
  * @see Main#mainProgrammatic(String[])
  *
  * @author  Misha Dmitriev
- * @date 17 January 2003
+ *  17 January 2003
  */
 public class PublicExceptions {
 

--- a/src/com/sun/tools/jmake/RefClassFinder.java
+++ b/src/com/sun/tools/jmake/RefClassFinder.java
@@ -14,7 +14,7 @@ import java.util.Set;
  * This class implements finding classes referencing other classes and members in various ways.
  *
  * @author Misha Dmitriev
- * @date 12 March 2004
+ * 12 March 2004
  */
 public class RefClassFinder {
 
@@ -119,7 +119,7 @@ public class RefClassFinder {
     /**
      * For the given class p.C, find each project class X referencing C, that is not a member of
      * package p and is not a direct or indirect subclass of C's directly enclosing class.
-     * (public -> protected transformation)
+     * (public -&gt; protected transformation)
      */
     public void findDiffPackageAndNotSubReferencingClasses1(ClassInfo classInfo) {
         String packageName = classInfo.packageName;
@@ -143,7 +143,7 @@ public class RefClassFinder {
     /**
      * For class p.C, find each project class X referencing C, whose top level enclosing
      * class is different from that of C.
-     * (public -> private transformation)
+     * (public -&gt; private transformation)
      */
     public void findReferencingClasses1(ClassInfo classInfo) {
         String topLevelEnclosingClass = classInfo.topLevelEnclosingClass;
@@ -166,7 +166,7 @@ public class RefClassFinder {
      * For class p.C, find each project class X referencing C, whose direct or indirect superclass
      * is C's directly enclosing class, or which is a member of package p, whose top level enclosing
      * class is different from that of C.
-     * (protected -> private transformation)
+     * (protected -&gt; private transformation)
      */
     public void findThisPackageOrSubReferencingClasses1(ClassInfo classInfo) {
         String directlyEnclosingClass = classInfo.directlyEnclosingClass;
@@ -194,7 +194,7 @@ public class RefClassFinder {
     /**
      * For class p.C, find each project class X referencing C, which is a member of package p and whose
      * top level enclosing class is different from that of C.
-     * (default -> private transformation)
+     * (default -&gt; private transformation)
      */
     public void findThisPackageReferencingClasses1(ClassInfo classInfo) {
         String topLevelEnclosingClass = classInfo.topLevelEnclosingClass;
@@ -220,7 +220,7 @@ public class RefClassFinder {
 
     /**
      * For class p.C, find each project class X referencing C, which is not a member of package p.
-     * (public -> default transformation)
+     * (public -&gt; default transformation)
      */
     public void findDiffPackageReferencingClasses1(ClassInfo classInfo) {
         String packageName = classInfo.packageName;
@@ -242,7 +242,7 @@ public class RefClassFinder {
     /**
      * For class p.C, find each project class X referencing C, which is not a member of package p and
      * whose direct or indirect superclass is C's directly enclosing class.
-     * (protected -> default transformation)
+     * (protected -&gt; default transformation)
      */
     public void findDiffPackageAndSubReferencingClasses1(ClassInfo classInfo) {
         String packageName = classInfo.packageName;
@@ -379,7 +379,7 @@ public class RefClassFinder {
     /**
      * Find all project classes that reference the given field, which are in different
      * packages and are direct or indirect subclasses of the member's declaring class
-     * (protected -> default transformation).
+     * (protected -&gt; default transformation).
      */
     public void findDiffPackageAndSubReferencingClassesForField(ClassInfo classInfo, int fieldNo) {
         findReferencingClassesForMember(classInfo, fieldNo, true, true, true);
@@ -401,7 +401,7 @@ public class RefClassFinder {
     /**
      * Find all project classes that reference the given method, which are in different
      * packages and are direct or indirect subclasses of the member's declaring class
-     * (protected -> default transformation)
+     * (protected -&gt; default transformation)
      */
     public void findDiffPackageAndSubReferencingClassesForMethod(ClassInfo classInfo, int methodNo) {
         findReferencingClassesForMember(classInfo, methodNo, false, true, true);

--- a/src/com/sun/tools/jmake/TextProjectDatabaseReader.java
+++ b/src/com/sun/tools/jmake/TextProjectDatabaseReader.java
@@ -29,7 +29,7 @@ import java.util.regex.Pattern;
  * Scala incremental compiler) and allows Pants to handle both uniformly.
  *
  * @author  Benjy Weinberger
- * @date 13 January 2013
+ * 13 January 2013
  */
 public class TextProjectDatabaseReader {
     public Map<String,PCDEntry> readProjectDatabaseFromFile(File infile) {

--- a/src/com/sun/tools/jmake/TextProjectDatabaseWriter.java
+++ b/src/com/sun/tools/jmake/TextProjectDatabaseWriter.java
@@ -29,7 +29,7 @@ import java.util.Set;
  * @see com.sun.tools.jmake.TextProjectDatabaseReader for details.
  *
  * @author  Benjy Weinberger
- * @date 13 January 2013
+ * 13 January 2013
  */
 public class TextProjectDatabaseWriter {
     private static Set<String> primitives = new LinkedHashSet<String>(

--- a/src/com/sun/tools/jmake/Utils.java
+++ b/src/com/sun/tools/jmake/Utils.java
@@ -19,7 +19,7 @@ import java.util.zip.ZipFile;
  * Utility functions used by other classes from this package.
  *
  * @author Misha Dmitriev
- * @date 23 January 2003
+ * 23 January 2003
  */
 public class Utils {
 


### PR DESCRIPTION
- Remove @date from javadoc.
- Escape '>' references
- Remove empty line in jarjar config's rename.rules
- Add a message to warn if jarjar.jar is missing